### PR TITLE
Add status badges to the GitHub CI/CD section

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@
   - **History**: [GitHub Deployments](https://github.com/smagara/AgilitySports_api/deployments)
 </details>
 
+<details>
+  <summary>📁 Current Agility Sports CI/CD Status</summary>
+
+  | Application | Environment | Tech | Status |
+  |---|---|---|---|
+  | Agility Sports Website | Production | Angular Web App | [![Build Status](https://github.com/smagara/AgilitySports_Web/actions/workflows/deployAgilitySports.js.yml/badge.svg)](https://github.com/smagara/AgilitySports_Web/actions) |
+  | Agility Sports API | Production | DotNet Core Minimal API | [![Build Status](https://github.com/smagara/AgilitySports_API/actions/workflows/azure-webapps-dotnet-core.yml/badge.svg)](https://github.com/smagara/AgilitySports_API/actions) |
+  | Agility Sports SQL | Production | Azure SQL | [![Build Status](https://github.com/smagara/AgilitySports_Data/actions/workflows/executsql.yml/badge.svg)](https://github.com/smagara/AgilitySports_Data/actions) |
+</details>
 
 ## 🏆 Certifications
 
@@ -154,3 +163,5 @@
 
 ## Traffic
 ![visitors](https://visitor-badge.laobi.icu/badge?page_id=smagara.visitor-badge)
+
+


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

Include status badges in the GitHub Actions CI/CD section for the Agility Sports sample application.

## Dependencies
- AgilitySports_Web repo GitHub Action
- AgilitySports_API repo GitHub Action
- AgilitySports_Data repo GitHub Action

## Type of change: README content

Please check relevant options

- [x] Cosmetics

## How Has This Been Tested?

Local preview

