### PR TITLE
Fix GitHub Profile Vercel broken links, Issue #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,8 +254,8 @@
 </details>
 
 ## 📈 GitHub Stats
-[![My GitHub Language Stats](https://github-readme-stats.vercel.app/api/top-langs/?username=smagara&langs_count=4&theme=tokyonight)]()
-[![My GitHub Stats](https://github-readme-stats.vercel.app/api/?username=smagara&count_private=true&theme=tokyonight&showicons=true)]()
+![My GitHub Language Stats](https://github-readme-stats-sigma-five.vercel.app/api/top-langs/?username=smagara&langs_count=4&theme=tokyonight)
+![My GitHub Usage Stats](https://github-readme-stats-sigma-five.vercel.app/api?username=smagara&show_icons=true&theme=tokyonight)
 
 ## Traffic
 ![visitors](https://visitor-badge.laobi.icu/badge?page_id=smagara.visitor-badge)


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

Fix for the GitHub issue Vercel links that are suddenly broken on my GitHub Profile page. #3 

## Dependencies
- None, except another Vercel volunteer link that may fare better.

Fixes or Implements # (issue) #3 

## Type of change: 

Please check relevant options

- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Deploy new URLs for GitHub statistics and observe the broken links are resolved.

## Checklist:

- [x] My code follows the style guidelines of this project, formatting and lint-ing
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if applicable
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules